### PR TITLE
chore: remove eprintln in from impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -52,8 +52,6 @@ impl From<&std::io::Error> for Error {
     fn from(err: &std::io::Error) -> Self {
         use std::io::ErrorKind;
 
-        eprintln!("{:?}", err);
-
         match err.kind() {
             ErrorKind::TimedOut => Error::new("tcp", "timed_out"),
             ErrorKind::ConnectionReset => Error::new("tcp", "reset"),


### PR DESCRIPTION
Remove an `eprintln!` left in the From impl for `std::io::Error`